### PR TITLE
chore: common 모듈 배포 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,5 +60,5 @@ tasks.named('test') {
 }
 
 tasks.withType(GenerateModuleMetadata).configureEach {
-    suppressedValidationErrors.add('dependencies-without-versions')
+    enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.yeoljeong'
-version = '0.0.1'
+version = '0.0.2'
 description = 'common-module'
 
 java {
@@ -38,27 +37,17 @@ repositories {
     mavenCentral()
 }
 
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.13"
-    }
-}
-
 dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
+    compileOnly platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
+    annotationProcessor platform('org.springframework.boot:spring-boot-dependencies:3.5.13')
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testCompileOnly 'org.projectlombok:lombok'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
-}
-
-tasks.withType(GenerateModuleMetadata).configureEach {
-    enabled = false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.5.13'
+    id 'java-library'
+    id 'maven-publish'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.yeoljeong'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.1'
 description = 'common-module'
 
 java {
@@ -14,8 +14,34 @@ java {
     }
 }
 
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GithubPackages"
+            url = uri("https://maven.pkg.github.com/10jeong/common-module")
+            credentials{
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+
 repositories {
     mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.13"
+    }
 }
 
 dependencies {
@@ -31,4 +57,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(GenerateModuleMetadata).configureEach {
+    suppressedValidationErrors.add('dependencies-without-versions')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'tripmate'
+rootProject.name = 'common-module'


### PR DESCRIPTION
### summary

> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

* `common-module`을 GitHub Packages에 배포할 수 있도록 Maven Publish 설정 코드 추가
* Spring Boot BOM을 기반으로 의존성 버전을 참조하도록 설정

### changes

> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

* `build.gradle`에 `maven-publish` 및 GitHub Packages 배포 repository 설정을 추가
* `settings.gradle`의 `rootProject.name`은 `common-module`로 변경

### background (or etc.)

> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

* GitHub Packages 배포를 위해 로컬 또는 CI 환경에 `GITHUB_USERNAME`, `GITHUB_TOKEN` 환경변수 설정이 필요해서 slack에 남겼습니다만 본인 계정 및 토큰을 사용해도 됩니다.
* `GITHUB_TOKEN`은 대상 저장소의 Packages Write권한을 포함해야 배포할 수 있습니다.
* 이후 다른 서비스에서 해당 모듈을 사용하려면 GitHub Packages repository 설정과 인증 정보가 함께 필요합니다.

closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released stable version 0.0.2
  * Enabled Maven publishing to GitHub Packages
  * Updated project build configuration and dependency management
  * Removed test-related dependencies and processors
  * Renamed project module to `common-module`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->