### PR TITLE
feat: global exception handler 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework:spring-web'
+    compileOnly 'jakarta.servlet:jakarta.servlet-api'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/com/yeoljeong/tripmate/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yeoljeong/tripmate/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.yeoljeong.tripmate.exception;
+
+import com.yeoljeong.tripmate.exception.constants.CommonErrorCode;
+import com.yeoljeong.tripmate.exception.constants.FieldErrorDetail;
+import com.yeoljeong.tripmate.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+		return ResponseEntity
+			.status(e.getErrorCode().getStatus())
+			.body(ApiResponse.error(e.getErrorCode()));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<List<FieldErrorDetail>>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+		List<FieldErrorDetail> fieldErrors = e.getBindingResult().getFieldErrors()
+			.stream()
+			.map(fe -> new FieldErrorDetail(fe.getField(), fe.getDefaultMessage()))
+			.toList();
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ApiResponse.error(CommonErrorCode.INVALID_INPUT, fieldErrors));
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+		return ResponseEntity
+			.status(HttpStatus.METHOD_NOT_ALLOWED)
+			.body(ApiResponse.error(CommonErrorCode.METHOD_NOT_ALLOWED));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleException(Exception e, HttpServletRequest request) {
+		log.error("[Unhandled Exception] {} {}", request.getMethod(), request.getRequestURI(), e);
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/exception/constants/FieldErrorDetail.java
+++ b/src/main/java/com/yeoljeong/tripmate/exception/constants/FieldErrorDetail.java
@@ -1,0 +1,4 @@
+package com.yeoljeong.tripmate.exception.constants;
+
+public record FieldErrorDetail(String field, String message) {}
+


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

전역 예외 처리 체계를 추가하여 API 예외 응답을 일관된 `ApiResponse` 포맷으로 반환하도록 개선했습니다.  
비즈니스 예외, 요청 값 검증 실패, 지원하지 않는 HTTP Method 요청, 예상하지 못한 서버 예외를 각각 분리해 처리하도록 구성했습니다.  
또한 Servlet 기반 예외 처리에 필요한 `jakarta.servlet-api` 의존성을 `compileOnly`로 추가하여 관련 타입을 컴파일 시점에 사용할 수 있도록 했습니다.

- `GlobalExceptionHandler`를 신규 추가하여 컨트롤러 계층에서 발생하는 주요 예외를 공통으로 처리합니다.
- `BusinessException` 발생 시 각 에러 코드에 정의된 HTTP Status와 에러 응답을 그대로 반환합니다.
- `@Valid` 등 요청 검증 실패 시 필드명과 메시지를 포함한 상세 오류 목록을 반환합니다.
- 지원하지 않는 HTTP Method 요청은 `METHOD_NOT_ALLOWED` 공통 에러 코드로 응답합니다.
- 처리되지 않은 예외는 서버 로그에 요청 Method/URI와 함께 기록하고, 클라이언트에는 `INTERNAL_SERVER_ERROR` 응답을 반환합니다.
- Servlet API 타입 사용을 위해 `jakarta.servlet-api`를 `compileOnly` 의존성으로 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

- **생성된 파일**
  - `src/main/java/com/yeoljeong/tripmate/exception/GlobalExceptionHandler.java`
    - 전역 예외 처리를 담당하는 `@RestControllerAdvice` 클래스 추가
    - Servlet 웹 애플리케이션 환경에서만 동작하도록 `@ConditionalOnWebApplication(type = SERVLET)` 적용
  - `src/main/java/com/yeoljeong/tripmate/exception/constants/FieldErrorDetail.java`
    - 요청 검증 실패 시 필드별 오류 정보를 담기 위한 record 추가
    - `field`, `message` 값을 응답 데이터로 전달

- **추가된 로직**
  - `BusinessException` 처리 로직 추가
    - 예외 내부의 `ErrorCode` 기준으로 HTTP Status와 공통 에러 응답 반환
  - `MethodArgumentNotValidException` 처리 로직 추가
    - 요청 DTO 검증 실패 시 `BindingResult`의 field error를 수집
    - 각 오류를 `FieldErrorDetail`로 변환하여 응답
    - `CommonErrorCode.INVALID_INPUT`과 함께 상세 필드 오류 목록 반환
  - `HttpRequestMethodNotSupportedException` 처리 로직 추가
    - 허용되지 않은 HTTP Method 요청에 대해 `405 METHOD_NOT_ALLOWED` 응답 반환
  - 일반 `Exception` 처리 로직 추가
    - 처리되지 않은 예외를 서버 로그에 남김
    - 클라이언트에는 내부 예외 상세 대신 공통 `INTERNAL_SERVER_ERROR` 응답 반환

- **수정된 파일**
  - `build.gradle`
    - `compileOnly 'jakarta.servlet:jakarta.servlet-api'` 의존성 추가
    - `HttpServletRequest` 등 Jakarta Servlet 타입을 컴파일 시점에 참조할 수 있도록 설정

- **삭제된 파일**
  - 없음

### background (or etc.) 
> 동료 개발자가 알아야 할 사항

- 이번 변경으로 API 예외 응답이 `ApiResponse.error(...)` 형식으로 통일됩니다. 신규 API 개발 시 별도 try-catch로 응답을 직접 만들기보다, 필요한 경우 `BusinessException`을 던지는 방식으로 처리하면 됩니다.
- 요청 검증 실패 응답에는 필드 단위 오류 목록이 포함됩니다. 프론트엔드에서는 `field`, `message` 구조를 기준으로 입력 폼 에러 표시를 연동할 수 있습니다.
- `GlobalExceptionHandler`는 Servlet 웹 애플리케이션 환경에서만 활성화됩니다. WebFlux 기반 환경에서는 동작하지 않습니다.
- 예상하지 못한 예외는 서버 로그에는 상세히 남지만, 클라이언트에는 공통 서버 에러만 내려갑니다. 운영 환경에서 내부 예외 정보가 노출되지 않도록 한 의도입니다.
- `jakarta.servlet-api`는 `compileOnly`로 추가되어 런타임 패키징 대상에는 포함되지 않습니다. Servlet 컨테이너 또는 Spring Boot 웹 환경에서 제공되는 API를 사용하는 전제입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 오류 응답을 표준화된 형식으로 제공하는 중앙 집중식 예외 처리 메커니즘 추가
  * 유효성 검사 실패 시 각 필드별 오류 세부정보가 포함된 상세한 오류 응답 제공
  * 지원되지 않는 HTTP 메서드 및 예상치 못한 오류에 대한 적절한 오류 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->