### PR TITLE
Feat/23 implement custom usercontext and propagation logic via common module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter'
+    compileOnly 'org.springframework:spring-webmvc'
 
     implementation 'org.springframework:spring-web'
     compileOnly 'jakarta.servlet:jakarta.servlet-api'

--- a/src/main/java/com/yeoljeong/tripmate/auth/LoginUser.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/LoginUser.java
@@ -1,0 +1,12 @@
+package com.yeoljeong.tripmate.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.yeoljeong.tripmate.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /*
+     * @LoginUser annotation에 대한 값을 검증하고 값을 추가합니다.
+     * */
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class)
+            && parameter.getParameterType().equals(UserContext.class);
+    }
+
+    @Nullable
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+        @Nullable ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+        @Nullable WebDataBinderFactory binderFactory) throws Exception {
+        return UserContextHolder.getContext();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/auth/UserContext.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/UserContext.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.auth;
+
+public record UserContext(String userId, String role) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/auth/UserContextHolder.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/UserContextHolder.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.auth;
+
+public class UserContextHolder {
+
+    /*
+     * UserContext를 ThreadLocal에 보관하는 로직을 수행합니다.
+     * */
+
+    private static final ThreadLocal<UserContext> holder = new ThreadLocal<>();
+
+    public static void setContext(UserContext context) {
+        holder.set(context);
+    }
+
+    public static UserContext getContext() {
+        return holder.get();
+    }
+
+    public static void clear() {
+        holder.remove();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/auth/UserContextInterceptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/UserContextInterceptor.java
@@ -1,0 +1,36 @@
+package com.yeoljeong.tripmate.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class UserContextInterceptor implements HandlerInterceptor {
+
+    /*
+     * 헤더를 읽어서 TreadLocal에 저장하며, 요청이 끝나면 clear()합니다.
+     * */
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) {
+        String userId = request.getHeader("X-User-Id");
+        String role = request.getHeader("X-User-Role");
+
+        if (userId == null || role == null) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+
+        UserContext context = new UserContext(userId, role);
+        UserContextHolder.setContext(context);
+
+        return true;
+
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+        Object handler, Exception ex) {
+        UserContextHolder.clear();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/config/WebMvcConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.yeoljeong.tripmate.config;
+
+import com.yeoljeong.tripmate.auth.LoginUserArgumentResolver;
+import com.yeoljeong.tripmate.auth.UserContextInterceptor;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new UserContextInterceptor())
+            .excludePathPatterns("/auth/login", "/auth/refresh", "/users/signup");
+
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserArgumentResolver());
+    }
+}


### PR DESCRIPTION
### summary
- MSA 환경에서 API Gateway로부터 전달된 사용자 인증 정보(Header)를 서비스 내부 스레드 전역에서 활용할 수 있도록 공통 인증 컨텍스트 인프라를 구축했습니다.
- Spring Security 의존성을 제거하여 가벼운 구조를 유지하면서도, `@LoginUser` 어노테이션을 통해 컨트롤러에서 간편하게 사용자 정보를 주입받을 수 있도록 설계했습니다.

### changes
- **`UserContext` (record)**: 헤더에서 추출한 `userId`와 `role`을 담는 불변 객체를 생성했습니다.
- **`UserContextHolder`**: `ThreadLocal`을 사용하여 요청이 들어온 스레드 내에서 `UserContext`를 전역적으로 공유 및 관리합니다.
- **`UserContextInterceptor`**:
    - Incoming Request의 `X-User-Id`, `X-User-Role` 헤더를 검사합니다.
    - 헤더 누락 시 `403 Forbidden`을 반환하며, 유효한 경우 `UserContextHolder`에 정보를 세팅합니다.
    - `afterCompletion` 단계에서 `clear()`를 호출하여 메모리 누수 및 스레드 간 데이터 오염을 방지합니다.
- **`LoginUser` & `LoginUserArgumentResolver`**:
    - 컨트롤러 파라미터에 `@LoginUser` 어노테이션 사용 시 `UserContextHolder`에 저장된 객체를 자동으로 바인딩합니다.
- **`WebMvcConfig`**:
    - 작성한 인터셉터와 리졸버를 스프링 빈 설정에 등록했습니다.
    - 로그인, 회원가입 등 인증이 필요 없는 퍼블릭 경로(`excludePathPatterns`)를 설정했습니다.

### background (or etc.)
- **인증 헤더 전제**: 본 로직은 Gateway에서 1차 인증을 마친 후 정보를 헤더로 넘겨준다는 신뢰를 바탕으로 동작합니다. 로컬 테스트 시 해당 헤더들을 직접 포함해야 합니다.
- **ThreadLocal 관리**: 인터셉터에서 자원 해제를 수행하고 있으나, 별도의 비동기 스레드(`@Async` 등)를 생성할 경우 해당 스레드까지 컨텍스트가 자동으로 전파되지 않으므로 주의가 필요합니다.
- **퍼블릭 경로 추가**: 향후 인증이 필요 없는 API가 추가될 경우 `WebMvcConfig`의 제외 경로 설정에 반드시 반영해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 (Chores)**
  * 인증 처리 인프라 개선 및 의존성 추가

---

**참고:** 이번 릴리스는 내부 시스템 개선으로 구성되어 있으며, 최종 사용자에게 직접적으로 보이는 새로운 기능은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->