### PR TITLE
Feat/50 implement internal passport token for gateway to service authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     implementation 'org.springframework:spring-web'
     compileOnly 'jakarta.servlet:jakarta.servlet-api'

--- a/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
@@ -1,30 +1,37 @@
 package com.yeoljeong.tripmate.auth.context;
 
+import com.yeoljeong.tripmate.auth.passport.PassportValidator;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+@RequiredArgsConstructor
 public class UserContextInterceptor implements HandlerInterceptor {
 
     /*
      * 헤더를 읽어서 TreadLocal에 저장하며, 요청이 끝나면 clear()합니다.
      * */
 
+    private static final String HEADER_PASSPORT = "X-Passport";
+    private final PassportValidator passportValidator;
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
         Object handler) {
-        String userId = request.getHeader("X-User-Id");
-        String role = request.getHeader("X-User-Role");
+        String passport = request.getHeader(HEADER_PASSPORT);
 
-        if (userId == null || role == null) {
+        if (passport == null) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return false;
         }
 
         try {
-            UUID userUUID = UUID.fromString(userId);
-            UserContextHolder.setContext(new UserContext(userUUID, role));
+            Claims claims = passportValidator.validate(passport);
+            UUID userId = UUID.fromString(claims.getSubject());
+            String role = claims.get("role", String.class);
+            UserContextHolder.setContext(new UserContext(userId, role));
         } catch (IllegalArgumentException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;

--- a/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.auth.context;
 
 import com.yeoljeong.tripmate.auth.passport.PassportValidator;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
@@ -32,7 +33,7 @@ public class UserContextInterceptor implements HandlerInterceptor {
             UUID userId = UUID.fromString(claims.getSubject());
             String role = claims.get("role", String.class);
             UserContextHolder.setContext(new UserContext(userId, role));
-        } catch (IllegalArgumentException e) {
+        } catch (JwtException | IllegalArgumentException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
         }

--- a/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
@@ -38,8 +38,17 @@ public class UserContextInterceptor implements HandlerInterceptor {
 
         try {
             Claims claims = passportValidator.validate(passport);
-            UUID userId = UUID.fromString(claims.getSubject());
+
+            String subject = claims.getSubject();
             String role = claims.get("role", String.class);
+
+            if (subject == null || subject.isBlank() || role == null || role.isBlank()) {
+                log.warn("[Passport] 필수 claim 누락 - uri: {}", request.getRequestURI());
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
+            }
+
+            UUID userId = UUID.fromString(subject);
             UserContextHolder.setContext(new UserContext(userId, role));
         } catch (ExpiredJwtException e) {
             log.warn("[Passport] 만료된 Passport - uri: {}", request.getRequestURI());

--- a/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/context/UserContextInterceptor.java
@@ -2,13 +2,19 @@ package com.yeoljeong.tripmate.auth.context;
 
 import com.yeoljeong.tripmate.auth.passport.PassportValidator;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+
+@Slf4j
 @RequiredArgsConstructor
 public class UserContextInterceptor implements HandlerInterceptor {
 
@@ -25,7 +31,9 @@ public class UserContextInterceptor implements HandlerInterceptor {
         String passport = request.getHeader(HEADER_PASSPORT);
 
         if (passport == null) {
+            log.warn("[Passport] X-Passport 헤더 없음 - uri: {}", request.getRequestURI());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
         }
 
         try {
@@ -33,7 +41,20 @@ public class UserContextInterceptor implements HandlerInterceptor {
             UUID userId = UUID.fromString(claims.getSubject());
             String role = claims.get("role", String.class);
             UserContextHolder.setContext(new UserContext(userId, role));
-        } catch (JwtException | IllegalArgumentException e) {
+        } catch (ExpiredJwtException e) {
+            log.warn("[Passport] 만료된 Passport - uri: {}", request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        } catch (SignatureException e) {
+            log.warn("[Passport] 서명 검증 실패 - uri: {}", request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        } catch (MalformedJwtException | UnsupportedJwtException e) {
+            log.warn("[Passport] 잘못된 Passport 형식 - uri: {}", request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        } catch (IllegalArgumentException e) {
+            log.warn("[Passport] userId UUID 파싱 실패 - uri: {}", request.getRequestURI());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
         }

--- a/src/main/java/com/yeoljeong/tripmate/auth/passport/PassportValidator.java
+++ b/src/main/java/com/yeoljeong/tripmate/auth/passport/PassportValidator.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.auth.passport;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+
+public class PassportValidator {
+
+    private final SecretKey internalSecretKey;
+
+    public PassportValidator(String base64Secret) {
+        byte[] keyBytes = Decoders.BASE64.decode(base64Secret);
+        this.internalSecretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public Claims validate(String passport) {
+        return Jwts.parser()
+            .verifyWith(internalSecretKey)
+            .build()
+            .parseSignedClaims(passport)
+            .getPayload();
+    }
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/config/PassportConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/config/PassportConfig.java
@@ -1,0 +1,16 @@
+package com.yeoljeong.tripmate.config;
+
+import com.yeoljeong.tripmate.auth.passport.PassportValidator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PassportConfig {
+
+    @Bean
+    public PassportValidator passportValidator(
+        @Value("${jwt.internal-secret}") String internalSecret) {
+        return new PassportValidator(internalSecret);
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/config/WebMvcConfig.java
+++ b/src/main/java/com/yeoljeong/tripmate/config/WebMvcConfig.java
@@ -2,18 +2,23 @@ package com.yeoljeong.tripmate.config;
 
 import com.yeoljeong.tripmate.auth.context.LoginUserArgumentResolver;
 import com.yeoljeong.tripmate.auth.context.UserContextInterceptor;
+import com.yeoljeong.tripmate.auth.passport.PassportValidator;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final PassportValidator passportValidator;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new UserContextInterceptor())
+        registry.addInterceptor(new UserContextInterceptor(passportValidator))
             .excludePathPatterns("/auth/login", "/auth/refresh", "/users/signup", "/internal/**");
 
     }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 서비스 간 통신 보안 및 사용자 인증 정보 신뢰성 확보를 위한 **X-Passport 검증 로직 도입**
- 기존에 `X-User-Id`, `X-User-Role` 헤더를 직접 읽던 방식에서 Gateway가 발행한 `X-Passport`(JWT)를 검증하여 `UserContext`를 생성하는 방식으로 전환
- 이를 위해 내부망 전용 JWT 라이브러리 추가 및 관련 인터셉터, 검증기 구현

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- **build.gradle**: JWT(jjwt) 라이브러리 의존성 추가 (0.13.0 버전)
- **UserContextInterceptor.java**: 
  - 기존의 개별 헤더(`X-User-Id` 등) 확인 로직 제거
  - `PassportValidator`를 주입받아 `X-Passport` 헤더의 유효성 검증 및 `UserContext` 설정 로직 추가
  - `JwtException` 및 `IllegalArgumentException` 발생 시 401(Unauthorized) 응답 처리
- **PassportValidator.java (신규)**: `internal-secret`을 기반으로 `X-Passport` JWT의 서명을 검증하고 Claims를 추출하는 핵심 로직 구현
- **PassportConfig.java (신규)**: 환경 변수(`jwt.internal-secret`)를 주입받아 `PassportValidator`를 빈으로 등록
- **WebMvcConfig.java**: 인터셉터 생성 시 `PassportValidator`를 전달하도록 수정

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- `application.yml` 또는 환경 변수에 `jwt.internal-secret` (Base64 인코딩 값) 설정이 필요합니다.
- Gateway에서 전달하는 Passport 토큰이 내부 시크릿 키로 서명되어 있어야 정상적으로 인증이 통과됩니다.
- 로컬 테스트 시 기존 헤더 방식(`X-User-Id`)은 더 이상 동작하지 않으니 유효한 Passport 토큰을 헤더에 실어 전송해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * JWT 관련 라이브러리 의존성 추가

* **Refactor**
  * 요청 인증을 JWT 토큰(패스포트) 검증 방식으로 전환
  * 인증 토큰에서 사용자 컨텍스트(식별자·권한)를 추출하도록 개선
  * 토큰 검증을 위한 구성 및 검증기(빈) 추가, 인터셉터 등록 방식 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->